### PR TITLE
fix: new ipfs api client

### DIFF
--- a/protocols/protocol.go
+++ b/protocols/protocol.go
@@ -76,7 +76,12 @@ func CheckIpfsConnection() error {
 
 	// connect ipfs node remote or local
 	if scontext.Config.Api.IpfsApiUrl != "" {
-		node, err = rpc.NewURLApiWithClient(scontext.Config.Api.IpfsApiUrl, nil)
+		node, err = rpc.NewURLApiWithClient(scontext.Config.Api.IpfsApiUrl, &http.Client{
+			Transport: &http.Transport{
+				Proxy:             http.ProxyFromEnvironment,
+				DisableKeepAlives: true,
+			},
+})
 	} else {
 		node, err = rpc.NewLocalApi()
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
fix: this error
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x285e5df]

goroutine 1 [running]:
github.com/ipfs/kubo/client/rpc.NewURLApiWithClient({0xc0007bbba8, 0x15}, 0x0)
	/home/es_admin/go/pkg/mod/github.com/ipfs/kubo@v0.29.0/client/rpc/api.go:152 +0x2df
github.com/sunriselayer/sunrise-data/protocols.CheckIpfsConnection()
	/home/es_admin/sunrise-data/protocols/protocol.go:79 +0x2c
github.com/sunriselayer/sunrise-data/cmd.init.func3(0xc000a4c300?, {0x2ee8366?, 0x4?, 0x2ee8236?})
	/home/es_admin/sunrise-data/cmd/validator.go:31 +0x1c8
github.com/spf13/cobra.(*Command).execute(0x4c5b140, {0x4eb8220, 0x0, 0x0})
	/home/es_admin/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0x4c5ae60)
	/home/es_admin/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/es_admin/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/sunriselayer/sunrise-data/cmd.Execute()
	/home/es_admin/sunrise-data/cmd/root.go:30 +0x1a
main.main()
	/home/es_admin/sunrise-data/main.go:23 +0xa8
```
