### PR TITLE
Fix IPFS connection check with custom IPFS API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Copy `config.default.toml` to `config.toml` and edit
 1. `keyring_backend`: `sunrised`'s keyring
 1. `sunrised_rpc`: `sunrised`'s RPC URL. To connect to a local chain, use `http://localhost:26657`
 
+Note that if you leave `ipfs_api_url` unset and configure `IPFS_PATH` for your IPFS daemon, you must configure the same `IPFS_PATH` for sunrise-da as well.
+
 ### Only L2 Publisher
 
 1. `publisher_account`: Account to send MetadataUrl of L2 data to Sunrise chain, $RISE balance required.

--- a/protocols/protocol.go
+++ b/protocols/protocol.go
@@ -76,7 +76,12 @@ func CheckIpfsConnection() error {
 
 	// connect ipfs node remote or local
 	if scontext.Config.Api.IpfsApiUrl != "" {
-		node, err = rpc.NewURLApiWithClient(scontext.Config.Api.IpfsApiUrl, nil)
+		node, err = rpc.NewURLApiWithClient(scontext.Config.Api.IpfsApiUrl, &http.Client{
+			Transport: &http.Transport{
+				Proxy:             http.ProxyFromEnvironment,
+				DisableKeepAlives: true,
+			},
+		})
 	} else {
 		node, err = rpc.NewLocalApi()
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Configuring `sunrise-da` with `ipfs_api_url` is currently broken, as kubo/client.rpc.NewURLApiWithClient expects non-nil http.Client arguments - when configured, `sunrise-da` will SIGSEGV with nil pointer dereference.

This PR also includes a note about `IPFS_PATH` - when running `ipfs daemon` with non-standard (`$HOME/.ipfs`) storage directory, then `sunrise-da` fails to figure out the configuration with ambiguous error message.